### PR TITLE
A few changes for halium 7.1

### DIFF
--- a/debian/android-headers.postinst
+++ b/debian/android-headers.postinst
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+update-alternatives --install \
+        /usr/include/android/android-config.h \
+        android-config_h \
+        /usr/include/android/android-config-generic.h \
+        500
+
+update-alternatives --install \
+        /usr/include/android/android-config.h \
+        android-config_h \
+        /usr/include/android/android-config-caf.h \
+        400

--- a/debian/android-headers.prerm
+++ b/debian/android-headers.prerm
@@ -1,0 +1,9 @@
+#/bin/bash
+
+update-alternatives --remove \
+        android-config_h \
+        /usr/include/android/android-config-generic.h \
+
+update-alternatives --remove \
+        android-config_h \
+        /usr/include/android/android-config-caf.h \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+android-headers (1:7.1) unstable; urgency=medium
+
+  * Update to Halium 7.1 release
+
+ -- JBBgameich <jbb.mail@gmx.de>  Mon, 24 Jul 2017 18:24:52 +0200
+ 
 android-headers (1:5.1) xenial; urgency=medium
 
   * Epoch in version number to supersede the version in ubuntu archive

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,16 @@
-android-headers (1:7.1) unstable; urgency=medium
+android-headers (1:7.1-1) unstable; urgency=medium
 
   * Update to Halium 7.1 release
 
  -- JBBgameich <jbb.mail@gmx.de>  Mon, 24 Jul 2017 18:24:52 +0200
  
-android-headers (1:5.1) xenial; urgency=medium
+android-headers (1:5.1-1) xenial; urgency=medium
 
   * Epoch in version number to supersede the version in ubuntu archive
 
  -- Bhushan Shah <bshah@kde.org>  Mon, 29 May 2017 16:21:36 +0530
 
-android-headers (5.1) unstable; urgency=medium
+android-headers (5.1-1) unstable; urgency=medium
 
   * Initial release (Closes: #nnnn)  <nnnn is the bug number of your ITP>
 

--- a/debian/control
+++ b/debian/control
@@ -18,4 +18,4 @@ Description: Android Platform Headers from AOSP releases
  different releases is required (e.g. for libhybris).
  .
  This package provides the platform development headers for core components
- of LineageOS, for the 5.1 release.
+ of LineageOS, for the 7.1 release.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: android-headers
 Priority: optional
 Maintainer: Rohan Garg <rohan@kde.org>
 Build-Depends: debhelper (>= 9)
-Standards-Version: 3.9.8
+Standards-Version: 4.0.0
 Section: libs
 Homepage: https://github.com/Halium/android-headers
 
@@ -18,5 +18,4 @@ Description: Android Platform Headers from AOSP releases
  different releases is required (e.g. for libhybris).
  .
  This package provides the platform development headers for core components
- of AOSP (Android Open Source Project), for the 4.4.2 release
-
+ of LineageOS, for the 5.1 release.

--- a/debian/patches/alternatives.patch
+++ b/debian/patches/alternatives.patch
@@ -1,0 +1,30 @@
+--- android-headers-7.1.orig/Makefile
++++ android-headers-7.1/Makefile
+@@ -5,9 +5,10 @@ all:
+ 	@echo "Use '$(MAKE) install' to install"
+ 
+ install:
++	bash ./genconf.sh
+ 	mkdir -p $(DESTDIR)/$(INCLUDEDIR)
+ 	mkdir -p $(DESTDIR)/$(PKGCONFIGDIR)
+-	cp android-config.h android-version.h $(DESTDIR)/$(INCLUDEDIR)
++	cp android-config.h android-config-caf.h android-version.h $(DESTDIR)/$(INCLUDEDIR)
+ 	cp android-headers.pc $(DESTDIR)/$(PKGCONFIGDIR)
+ 	sed -i -e s:prefix=/usr:prefix=$(PREFIX):g $(DESTDIR)/$(PKGCONFIGDIR)/android-headers.pc
+ 	cp -r hardware $(DESTDIR)/$(INCLUDEDIR)
+@@ -20,3 +21,6 @@ install:
+ 	cp -r libnfc-nxp $(DESTDIR)/$(INCLUDEDIR)
+ 	cp -r private $(DESTDIR)/$(INCLUDEDIR)
+ 	cp -r log $(DESTDIR)/$(INCLUDEDIR)
++
++clean:
++	if [ -f android-config-caf.h ]; then rm android-config-caf.h; fi
+--- /dev/null
++++ android-headers-7.1/genconf.sh
+@@ -0,0 +1,6 @@
++sed '/\/\* CONFIG GOES HERE/,$d' android-config.h > android-config-caf.h
++cat <<EOF >> android-config-caf.h
++#define QCOM_BSP 1
++#define QTI_BSP 1
++EOF
++sed '0,/\/\* CONFIG GOES HERE/d' android-config.h >> android-config-caf.h 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+alternatives.patch


### PR DESCRIPTION
* Add revision (format 3.0 quilt needs to have one)
* Update the package description (we don't use AOSP, but Lineageos)
* Update changelog for 7.1

Maybe this should be merged to a new halium-7.1 branch.